### PR TITLE
javafx updated to 16

### DIFF
--- a/JavaFX11.iml
+++ b/JavaFX11.iml
@@ -18,5 +18,6 @@
     <orderEntry type="library" name="Maven: org.openjfx:javafx-base:win:11" level="project" />
     <orderEntry type="library" name="Maven: org.openjfx:javafx-fxml:11" level="project" />
     <orderEntry type="library" name="Maven: org.openjfx:javafx-fxml:win:11" level="project" />
+    <orderEntry type="library" name="javafx.base" level="application" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
-    <name>JavaFX11</name>
+    <name>JavaFX16</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
         <mainClass>hu.unideb.inf.MainApp</mainClass>
     </properties>
 
@@ -25,12 +25,12 @@
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
-            <version>11</version>
+            <version>16</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
-            <version>11</version>
+            <version>16</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
1. MacOS alatt a font kivehetetlenné vált ezért frissíteni kellett a Javafx verziót 16-ra.
2. Emellett a configba be lett húzva a javafx sdk.